### PR TITLE
reduces backup size

### DIFF
--- a/lms/config.json
+++ b/lms/config.json
@@ -40,7 +40,7 @@
   "privileged": [ "SYS_ADMIN", "DAC_READ_SEARCH" ],
   "xprivileged": [ "NET_ADMIN", "SYS_ADMIN", "SYS_RAWIO", "SYS_TIME", "SYS_NICE", "SYS_RESOURCE", "SYS_PTRACE", "SYS_MODULE" , "DAC_READ_SEARCH" ],
   "host_network": true,
-  "backup_exclude": [ "/data/music", "/data/mount", "/data/mnt" ],
+  "backup_exclude": [ "*/*/" ],
   "ingress": true,
   "ingress_port": 0,
   "panel_icon": "mdi:music-box",


### PR DESCRIPTION
Trying to fix #11 as I encountered this as well.

For me, latest version of addon (v0.0.50) still takes a backup of cache directory.

This PR excludes everything from the addon's data directory except options.json