### PR TITLE
Bump Lyrion Music Server to 9.1.1

### DIFF
--- a/lms/CHANGELOG.md
+++ b/lms/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [9.1.1.0] 2026-06-24
+
+### Changes
+ - LMS 9.1.1
+
 ## [9.1.0.4] 2026-06-03
 ### Changes
  - update image name

--- a/lms/Dockerfile
+++ b/lms/Dockerfile
@@ -39,7 +39,7 @@ FROM base
 # Bump cpan build to same version if possible
 #  ARG url="http://www.mysqueezebox.com/update/?version=8.0&revision=1&geturl=1&os=deb"
 # xlatest_lms=$(wget -q -O - "${url}" | sed 's/_all\.deb/_'$(arch | sed 's/arm.*/arm/' | sed 's/x86_64/amd64/' | sed 's/aarch64/arm/')'\.deb/') && \
-ARG purl="https://downloads.lms-community.org/LyrionMusicServer_v9.1.0/lyrionmusicserver_9.1.0_all.deb"
+ARG purl="https://downloads.lms-community.org/LyrionMusicServer_v9.1.1/lyrionmusicserver_9.1.1_all.deb"
 ARG debug=true
 ARG target_uid=1000
 ARG BUILD_ARCH

--- a/lms/README.md
+++ b/lms/README.md
@@ -9,7 +9,7 @@ LMS formerly the [Logitech Media Server][sdf] is a cross-platform streaming medi
 
 [![Open your Home Assistant instance and show the add app repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fpssc%2Fha-addon-lms%2F) or use the following addon repo manually https://github.com/pssc/ha-addon-lms/ in the supervisor addon tab following the stacked triple dots and selecting repositories.
 
-This app is based on the debian package for version 9.1.0 from https://lyrion.org/lms-server-repository/ and will track the latest stable release as time allows. 
+This app is based on the debian package for version 9.1.1 from https://lyrion.org/lms-server-repository/ and will track the latest stable release as time allows. 
 | :warning: Unfortunately the latest Squeezebox Radio firmware (7.7.3) comes with a bug which prevents it from connecting correctly to LMS formerly the Logitech Media Server 8+. See https://github.com/Logitech/slimserver#sb-radio-and-logitech-media-server-8 for details and an easy mitigation. |
 | --- |
 
@@ -36,7 +36,7 @@ The i386 build is becomming increasingly difficult and should be considered at r
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-prod-green.svg
-[release-shield]: https://img.shields.io/badge/version-v9.1.0.4-green.svg
+[release-shield]: https://img.shields.io/badge/version-v9.1.1.0-green.svg
 
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [discord-shield]: https://img.shields.io/discord/478094546522079232.svg

--- a/lms/config.yaml
+++ b/lms/config.yaml
@@ -1,5 +1,5 @@
 name: LMS Lyrion Music Server(Formerly Logitech Media Server)
-version: 9.1.0.4
+version: 9.1.1.0
 slug: lms
 description: LMS Lyrion Music Server, Formerly the Logitech Media Server & SqueezeBox Server
   Server & UPNP Music Server


### PR DESCRIPTION
Bumps Lyrion Music Server from 9.1.0 to the latest stable release, **9.1.1** (released 2026-06-17). The `.deb` download URL was verified to return HTTP 200.

### Changes
- `lms/Dockerfile` — `purl` ARG points to `LyrionMusicServer_v9.1.1/lyrionmusicserver_9.1.1_all.deb`
- `lms/config.yaml` — addon `version` `9.1.0.4` → `9.1.1.0` (following the existing `<lms-version>.<addon-revision>` scheme)
- `lms/README.md` — base-package version reference and release badge updated to `9.1.1` / `v9.1.1.0`
- `lms/CHANGELOG.md` — new `[9.1.1.0]` entry

The slimserver-vendor build pin (`public/9.2` @ `0aa04a0…`) is left unchanged, as it is a separate XS-module build workaround unrelated to the LMS package version.